### PR TITLE
Gitbucket color scheme

### DIFF
--- a/scripts/components/Root.js
+++ b/scripts/components/Root.js
@@ -34,7 +34,7 @@ export default class Root extends Directory {
     const arrow = this.state.expanded ? 'octicon octicon-chevron-down' : 'octicon octicon-chevron-right';
     return (
       <div className="tree-node">
-        <button className="root-expander" onClick={() => this.toggleFolder(`${this.state.rootPath}/explore/${this.state.branch}`)} >
+        <button className="root-expander btn btn-default" onClick={() => this.toggleFolder(`${this.state.rootPath}/explore/${this.state.branch}`)} >
           <i className={arrow} />
         </button>
         <a href={this.state.rootPath} className="submenu-files" >

--- a/src/main/resources/explorer/assets/plugin-explorer.css
+++ b/src/main/resources/explorer/assets/plugin-explorer.css
@@ -43,8 +43,9 @@ li.active .file-tree {
 }
 .root-expander {
   position: absolute;
-  padding: 2px 2px 0 5px;
-  right: 5px;
+  padding: 2px 1px 0px 5px;
+  width: 21px;
+  right: 15px;
   top: 10px;
   box-shadow: none;
   line-height: 1.5;
@@ -52,10 +53,16 @@ li.active .file-tree {
   background-color: #f4f4f4;
   border: 1px solid #ddd;
   border-radius: 3px;
+  outline: none !important;
 }
-.root-expander > .octicon {
-  font-size: 18px;
-  font-weight: 700;
+.root-expander > .octicon-chevron-right {
+  width: 12px;
+}
+.root-expander > .octicon-chevron-down {
+  width: 14px;
+}
+.root-expander:hover > .octicon {
+  color: rgb(60, 141, 188);
 }
 .file-tree button {
   border: none;


### PR DESCRIPTION
The design of the arrow icon in the explorer view is a little bit off. This PR adds the Gitbucket color scheme to the icon and removes the outlines when it is focused.